### PR TITLE
Support capnp ID generation

### DIFF
--- a/keymaps/capnp.cson
+++ b/keymaps/capnp.cson
@@ -1,0 +1,2 @@
+'atom-text-editor':
+  'ctrl-alt-g': 'capnp:newID'

--- a/lib/capnp.coffee
+++ b/lib/capnp.coffee
@@ -1,5 +1,5 @@
 {CompositeDisposable} = require 'atom'
-bignum                  = require 'bignum'
+bignum                = require 'big-integer'
 module.exports = CapnpID =
   subscriptions: null
 
@@ -21,4 +21,4 @@ module.exports = CapnpID =
     capnpID = @genCapnpID()
     editor = atom.workspace.getActiveTextEditor()
     txt = editor.getText()
-    editor.setText("#{capnpID}\n\n"+txt)
+    editor.setText("@0x#{capnpID};\n"+txt)

--- a/lib/capnp.coffee
+++ b/lib/capnp.coffee
@@ -1,0 +1,24 @@
+{CompositeDisposable} = require 'atom'
+bignum                  = require 'bignum'
+module.exports = CapnpID =
+  subscriptions: null
+
+  activate: (state) ->
+    # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
+    @subscriptions = new CompositeDisposable
+
+    # Register command that toggles this view
+    @subscriptions.add atom.commands.add 'atom-workspace',
+      'capnp:newID': => @newCapnpID()
+
+  deactivate: ->
+    @subscriptions.dispose()
+
+  randint: (min=0, max) ->  min + Math.floor(Math.random() * (max - min + 1))
+  genCapnpID: -> bignum(@randint(0, Math.pow(2, 64))).or(bignum(1).shiftLeft(63)).toString(16)
+     #Number(@randint(0, Math.pow(2,64)) | 1<<63).toString(16) #convert to hex.
+  newCapnpID: ->
+    capnpID = @genCapnpID()
+    editor = atom.workspace.getActiveTextEditor()
+    txt = editor.getText()
+    editor.setText("#{capnpID}\n\n"+txt)

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   "engines": {
     "atom": ">0.50.0"
   },
-  "dependencies": {}
+  "main": "./lib/capnp.coffee",
+  "dependencies": {
+    "bignum": "*"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   },
   "main": "./lib/capnp.coffee",
   "dependencies": {
-    "bignum": "*"
+    "big-integer": "*"
   }
 }


### PR DESCRIPTION
This pull request adds a new command `Capnp:newID` to atom workspace  instead of executing command `capnp id` or requiring it to be installed on the machine.


