### PR TITLE
security update use capnp > 1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "language-capnproto",
+  "version": "0.3.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "capnpid": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/capnpid/-/capnpid-0.1.2.tgz",
+      "integrity": "sha512-ML957DNotkP1MdHCwafaGhfj58GL32VIDPI++VgIUNsnVtDmHZRGNqadMgr11Dn+fNLHzlQArPQo0Atphps0MQ=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-capnproto",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Adds capnproto schema language support to atom",
   "repository": "https://github.com/tekacs/language-capnproto",
   "license": "ISC",
@@ -9,6 +9,6 @@
   },
   "main": "./lib/capnp.coffee",
   "dependencies": {
-    "capnpid": "^0.1.2"
+    "capnpid": ">0.1.2"
   }
 }


### PR DESCRIPTION
Ensure all the schemas has at least (1<<63) id. logic implemented in capnpid lib > 1.2 